### PR TITLE
Fix Page Load key name in camp_scraper

### DIFF
--- a/camp_scraper.py
+++ b/camp_scraper.py
@@ -66,7 +66,7 @@ def fill_columns(camp):
             camp["Page Load?"] = "No Link"
             camp["Lat"] = camp["Long"] = camp["start_date"] = camp["end_date"] = ""
     except Exception as e:
-        camp["Page Load"] = f"Error: {e}"
+        camp["Page Load?"] = f"Error: {e}"
         camp["Lat"] = camp["Long"] = camp["start_date"] = camp["end_date"] = ""
     time.sleep(1)  # Avoid hammering servers
 


### PR DESCRIPTION
## Summary
- fix typo so the `Page Load?` column is updated in the exception handler

## Testing
- `python3 -m py_compile camp_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff99899fc832980e5a6c46411cc3d