### PR TITLE
Use environment variables for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+gcreds.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # CSP Scraping Project
+
+This project relies on a couple of API keys that must be provided via environment variables before running the scraper:
+
+* `GOOGLE_API_KEY` – Google Maps API key used for geocoding requests.
+* `OPENROUTER_API_KEY` – API key for OpenRouter used to extract structured data from pages.
+
+Ensure these variables are set in your environment so `camp_scraper.py` can access them.

--- a/camp_scraper.py
+++ b/camp_scraper.py
@@ -13,6 +13,7 @@ import re
 from bs4 import BeautifulSoup
 import json
 import copy
+import os
 
 # CONFIG
 URLS = [
@@ -31,7 +32,7 @@ client = gspread.authorize(creds)
 sheet = client.open_by_key(SHEET_ID).worksheet(TAB_NAME)
 
 # Load GMaps Config
-GOOGLE_API_KEY = "AIzaSyBOUjqc42Rd38abVDRzYdbUrlxhJo_9SyI"  # Replace with your real API key
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 gmaps = GoogleMaps(key=GOOGLE_API_KEY)
 
 def fill_columns(camp):
@@ -108,7 +109,7 @@ def get_llm_data(res, camp):
     # row["LLM_INPUT"] = snippet
 
     # Call OpenRouter API to extract structured info
-    OPENROUTER_API_KEY = "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"
+    OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
     prompt = f"""
     You are a structured data extractor. From the following text, extract ONLY the values below and return them in strict JSON format. You are looking for
     information about soccer camps, including the event name, start and end dates, ages, and cost. Only extract data if you


### PR DESCRIPTION
## Summary
- remove hard-coded API keys from `camp_scraper.py`
- rely on `GOOGLE_API_KEY` and `OPENROUTER_API_KEY` environment variables

## Testing
- `python -m py_compile camp_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_683fe8e2519083299774b963cda0fc87