### PR TITLE
Add Exact Sports sheet scraper and geocode utils

### DIFF
--- a/camp_scraper.py
+++ b/camp_scraper.py
@@ -1,0 +1,100 @@
+from bs4 import BeautifulSoup
+import requests
+import json
+import copy
+import os
+
+def get_llm_data(res, camp):
+    soup = BeautifulSoup(res.text, "html.parser")
+    text_blocks = soup.find_all(["p", "li", "div"])
+    relevant_lines = []
+    for tag in text_blocks:
+        if tag.text:
+            text = tag.text.strip()
+            text_lower = text.lower()
+            if any(keyword in text_lower for keyword in ["camp", "date", "session", "ages", "$", "–", "to", "through"]) or any(char.isdigit() for char in text_lower):
+                relevant_lines.append(text)
+    snippet = "\n".join(relevant_lines)[:5000]
+    OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+    prompt = f"""
+    You are a structured data extractor. From the following text, extract ONLY the values below and return them in strict JSON format. You are looking for
+    information about soccer camps, including the event name, start and end dates, ages, and cost. Only extract data if you
+    are confident there is a soccer camp occurring in the near future. Do not return data just because you see the word soccer.
+    There should be at least the word camp and probably a start date of some kind to represent a valid camp.
+    If you are not confident, return an empty string for all fields. The text may contain various formats of dates.
+    You may encounter data on multiple camps. If this is the case, return several JSON objects in an array. They may often be contained in an HTML table format.
+    If you find a start_date but no end_date, assume the end_date is the same as the start_date.
+
+    Fields:
+    - event_name
+    - start_date
+    - end_date
+    - ages
+    - cost
+
+    Text:
+    \"\"\"
+    {snippet}
+    \"\"\"
+
+    Return only this format:
+    {{"event_name":"", "start_date": "", "end_date": "", "ages": "", "cost": ""}}
+
+    Even if the text does not contain all fields, return an empty string for those fields. Do not return any other text or explanation, just the JSON.
+    """
+
+    headers_llm = {
+        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+        "Content-Type": "application/json"
+    }
+    payload = {
+       "model": "google/gemma-3n-e4b-it:free",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.2
+    }
+
+    addl_camps = []
+    try:
+        llm_resp = requests.post("https://openrouter.ai/api/v1/chat/completions", headers=headers_llm, data=json.dumps(payload))
+        llm_json = llm_resp.json()
+        if "choices" in llm_json and llm_json["choices"]:
+            llm_output = llm_json["choices"][0]["message"]["content"]
+        else:
+            raise ValueError("No 'choices' in LLM response")
+        if llm_output.startswith("```"):
+            llm_output = llm_output.strip("`").strip()
+        json_start = llm_output.find('[')
+        if json_start == -1:
+            raise ValueError("No '[' found in LLM output")
+        json_snippet = llm_output[json_start:]
+        try:
+            parsed = json.loads(json_snippet)
+        except json.JSONDecodeError:
+            raise
+        try:
+            if isinstance(parsed, list) and len(parsed) > 0:
+                camp["Camp Found?"] = "Yes"
+                camp.update({
+                    "Event Details": parsed[0].get("event_name", camp.get("Event Details")),
+                    "start_date": parsed[0].get("start_date", ""),
+                    "end_date": parsed[0].get("end_date", ""),
+                    "Ages / Grade Level": parsed[0].get("ages", ""),
+                    "Cost": parsed[0].get("cost", "")
+                })
+                for camp_obj in parsed[1:]:
+                    new_camp = copy.deepcopy(camp)
+                    new_camp.update({
+                        "Event Details": camp_obj.get("event_name", camp.get("Event Details")),
+                        "start_date": camp_obj.get("start_date", ""),
+                        "end_date": camp_obj.get("end_date", ""),
+                        "Ages / Grade Level": camp_obj.get("ages", ""),
+                        "Cost": camp_obj.get("cost", "")
+                    })
+                    addl_camps.append(new_camp)
+            else:
+                camp["Camp Found?"] = "No"
+        except json.JSONDecodeError:
+            pass
+    except Exception:
+        camp["start_date"] = camp["end_date"] = camp["Ages / Grade Level"] = camp["Cost"] = "LLM Error"
+    return addl_camps

--- a/exact_sports_scraper.py
+++ b/exact_sports_scraper.py
@@ -1,104 +1,94 @@
+import os
 import requests
-from bs4 import BeautifulSoup
-import csv
-from geopy.geocoders import Nominatim
-import time
+import pandas as pd
+from lxml import html
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+from geocode_utils import get_lat_long
 
-# Initialize geolocator
-geolocator = Nominatim(user_agent="exact_sports_scraper")
+URL = "https://exactsports.com/soccer/#tve-jump-1896baece7f"
+XPATH = "/html/body/div[2]/div[1]/div/div/div[10]/div[2]/div[2]/div[2]/div/div/div[2]/table"
 
-# URL of the EXACT Sports Soccer Camps page
-url = "https://exactsports.com/soccer/#tve-jump-1896baece7f"
+SHEET_ID = os.getenv("SHEET_ID")
+if not SHEET_ID:
+    raise EnvironmentError("SHEET_ID environment variable not set")
+TAB_NAME = "Camps"
+CREDS_FILE = "gcreds.json"
 
-# Send a GET request to the page
-response = requests.get(url)
-soup = BeautifulSoup(response.content, "html.parser")
+scope = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
+creds = ServiceAccountCredentials.from_json_keyfile_name(CREDS_FILE, scope)
+client = gspread.authorize(creds)
+sheet = client.open_by_key(SHEET_ID).worksheet(TAB_NAME)
 
-# Find the table using the provided XPath
-# Note: BeautifulSoup doesn't support XPath directly, so we need to find the table by other means
-# Assuming the table has a unique class or id; if not, adjust the selector accordingly
-table = soup.find("table")
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
 
-# Prepare CSV file
-csv_file = "exact_sports_soccer_camps.csv"
-fieldnames = [
-    "Camp Name", "Camp Organizer", "Camp Type", "Image", "URL", "Lat", "Long",
-    "Start_date", "End_date", "City", "State", "Grade Level", "Ages", "Division", "Cost", "Gender"
-]
 
-with open(csv_file, mode='w', newline='', encoding='utf-8') as file:
-    writer = csv.DictWriter(file, fieldnames=fieldnames)
-    writer.writeheader()
+def scrape_exact_sports():
+    res = requests.get(URL, headers=HEADERS)
+    res.raise_for_status()
+    tree = html.fromstring(res.content)
+    table = tree.xpath(XPATH)
+    if not table:
+        raise ValueError("Could not locate camps table")
+    rows = table[0].xpath(".//tr")[1:]
 
-    # Iterate over table rows
-    for row in table.find_all("tr")[1:]:  # Skip header row
-        cols = row.find_all("td")
-        if len(cols) < 5:
-            continue  # Skip rows that don't have enough columns
+    records = []
+    for row in rows:
+        cells = row.xpath("./td")
+        if len(cells) < 5:
+            continue
+        gender = cells[0].text_content().strip()
+        state = cells[1].text_content().strip()
+        camp_name = cells[2].text_content().strip()
+        date = cells[3].text_content().strip()
+        link = cells[4].xpath(".//a/@href")
+        camp_url = link[0] if link else ""
 
-        gender = cols[0].get_text(strip=True)
-        state = cols[1].get_text(strip=True)
-        camp_name = cols[2].get_text(strip=True)
-        date = cols[3].get_text(strip=True)
-        url_tag = cols[4].find("a")
-        camp_url = url_tag['href'] if url_tag else ""
-
-        # Since the camps are one-day events, start and end dates are the same
         start_date = end_date = date
-
-        # Fetch additional details from the camp URL
         city = ""
         lat = ""
-        lon = ""
-        grade_level = ""
-        ages = ""
-        cost = ""
-        if camp_url:
-            camp_response = requests.get(camp_url)
-            camp_soup = BeautifulSoup(camp_response.content, "html.parser")
-            # Example: Extract city from the camp page
-            # Adjust the selector based on the actual structure of the camp pages
-            location_tag = camp_soup.find("div", class_="location")
-            if location_tag:
-                city = location_tag.get_text(strip=True)
-                # Geocode the address to get lat and lon
-                try:
-                    location = geolocator.geocode(f"{city}, {state}")
-                    if location:
-                        lat = location.latitude
-                        lon = location.longitude
-                except:
-                    pass
-            # Example: Extract grade level, ages, and cost
-            # Adjust the selectors based on the actual structure of the camp pages
-            details = camp_soup.find_all("div", class_="camp-detail")
-            for detail in details:
-                text = detail.get_text(strip=True)
-                if "Grade Level" in text:
-                    grade_level = text.split(":")[-1].strip()
-                elif "Ages" in text:
-                    ages = text.split(":")[-1].strip()
-                elif "Cost" in text:
-                    cost = text.split(":")[-1].strip()
+        lng = ""
 
-        # Write the row to CSV
-        writer.writerow({
+        if camp_url:
+            try:
+                camp_resp = requests.get(camp_url, headers=HEADERS, timeout=10)
+                camp_tree = html.fromstring(camp_resp.content)
+                loc_el = camp_tree.xpath("//div[contains(@class,'location')]//text()")
+                if loc_el:
+                    city = loc_el[0].strip()
+            except Exception:
+                pass
+
+        lat, lng, geo_city = get_lat_long(f"{camp_name}, {state}")
+        if not city:
+            city = geo_city
+
+        records.append({
             "Camp Name": camp_name,
             "Camp Organizer": "ExactSports",
             "Camp Type": "collaborative",
             "Image": "",
             "URL": camp_url,
             "Lat": lat,
-            "Long": lon,
+            "Long": lng,
             "Start_date": start_date,
             "End_date": end_date,
             "City": city,
             "State": state,
-            "Grade Level": grade_level,
-            "Ages": ages,
+            "Grade Level": "",
+            "Ages": "",
             "Division": "",
-            "Cost": cost,
-            "Gender": gender
+            "Cost": "",
+            "Gender": gender,
         })
 
-print(f"Data has been written to {csv_file}")
+    if records:
+        df = pd.DataFrame(records)
+        df = df.replace({pd.NA: ""}).fillna("")
+        sheet.append_rows(df.values.tolist())
+
+
+if __name__ == "__main__":
+    scrape_exact_sports()

--- a/geocode_utils.py
+++ b/geocode_utils.py
@@ -1,0 +1,25 @@
+import os
+from googlemaps import Client as GoogleMaps
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+if not GOOGLE_API_KEY:
+    raise EnvironmentError("GOOGLE_API_KEY environment variable not set")
+
+gmaps = GoogleMaps(key=GOOGLE_API_KEY)
+
+
+def get_lat_long(place: str):
+    """Return (lat, lng, city) for a place using Google Maps geocoding."""
+    try:
+        geo = gmaps.geocode(place.strip())
+        if geo:
+            loc = geo[0]["geometry"]["location"]
+            city = ""
+            for component in geo[0]["address_components"]:
+                if "locality" in component["types"]:
+                    city = component["long_name"]
+                    break
+            return loc["lat"], loc["lng"], city
+    except Exception:
+        pass
+    return "", "", ""


### PR DESCRIPTION
## Summary
- pull geocoding logic into `geocode_utils.py`
- update `nsr_scraper.py` to use the shared geocoder
- add `camp_scraper.py` with `get_llm_data` for tests
- rewrite `exact_sports_scraper.py` to scrape the table at the provided XPath and push results to Google Sheets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b6c5e030832983c587630245be48