### PR TITLE
Fix exact_sports_scraper DataFrame return

### DIFF
--- a/exact_sports_scraper.py
+++ b/exact_sports_scraper.py
@@ -161,6 +161,7 @@ def create_dataframe_and_write_to_csv(data, output_file):
     # Write the DataFrame to a CSV file
     df.to_csv(output_file, index=False)
     print(f"DataFrame written to {output_file}")
+    return df
 
 def main():
     """


### PR DESCRIPTION
## Summary
- return the DataFrame from `create_dataframe_and_write_to_csv`
- ensure `exact_sports_scraper.py` ends with a newline

## Testing
- `python -m pytest -q`
- manual check that `create_dataframe_and_write_to_csv` returns a DataFrame

------
https://chatgpt.com/codex/tasks/task_e_6842316a8e708329b2c1574a763dec43