### PR TITLE
Fix duplicate return in create_dataframe_and_write_to_csv

### DIFF
--- a/exact_sports_scraper.py
+++ b/exact_sports_scraper.py
@@ -157,7 +157,6 @@ def create_dataframe_and_write_to_csv(data, output_file):
     # Write the DataFrame to a CSV file
     df.to_csv(output_file, index=False)
     print(f"DataFrame written to {output_file}")
-    return df
 
     return df
 


### PR DESCRIPTION
## Summary
- remove unreachable `return` in `create_dataframe_and_write_to_csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684236bb3f8083299c087bf7932d4f71