### PR TITLE
Add College Soccer Prospects scraper

### DIFF
--- a/college_soccer_prospects_scraper.py
+++ b/college_soccer_prospects_scraper.py
@@ -1,0 +1,41 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Dict
+from camp_scraper import get_llm_data
+
+URLS = [
+    "https://men.collegesoccerprospects.com/",
+    "https://women.collegesoccerprospects.com/",
+]
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
+
+def scrape_csp_pages(urls: List[str] = URLS) -> List[Dict[str, str]]:
+    """Scrape camp data from College Soccer Prospects sites."""
+    camps: List[Dict[str, str]] = []
+    for url in urls:
+        try:
+            res = requests.get(url, headers=HEADERS, timeout=10)
+        except Exception:
+            continue
+        camp = {
+            "Camp Info URL": url,
+            "Camp Found?": "",
+            "Event Details": "",
+            "start_date": "",
+            "end_date": "",
+            "Ages / Grade Level": "",
+            "Cost": "",
+        }
+        addl = get_llm_data(res, camp)
+        camps.append(camp)
+        if addl:
+            camps.extend(addl)
+    return camps
+
+if __name__ == "__main__":
+    data = scrape_csp_pages()
+    for item in data:
+        print(item)


### PR DESCRIPTION
## Summary
- add a minimal scraper for men and women College Soccer Prospects pages
- use `get_llm_data` to parse information from each URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423f4e486483299ddb6346d7c9c8a3